### PR TITLE
Update paste-gpg-key-id.md

### DIFF
--- a/data/reusables/gpg/paste-gpg-key-id.md
+++ b/data/reusables/gpg/paste-gpg-key-id.md
@@ -4,8 +4,8 @@
    git config --global user.signingkey 3AA5C34371567BD2
    ```
 
-   Alternatively, when setting a subkey include the `!` suffix. In this example, the GPG subkey ID is `4BB6D45482678BE3`:
+   Alternatively, you may want to use a subkey. In this example, the GPG subkey ID is `4BB6D45482678BE3`:
 
    ```shell
-   git config --global user.signingkey 4BB6D45482678BE3!
+   git config --global user.signingkey 4BB6D45482678BE3
    ```


### PR DESCRIPTION
Remove the advice about a trailing '!'  This definitely does not work for me on Linux with gpg and git.  Leaving off the trailing '!' works perfectly however.
